### PR TITLE
Bug fix: při loadu listingu se automaticky zapne contact load

### DIFF
--- a/contexts/ListingContext.js
+++ b/contexts/ListingContext.js
@@ -211,6 +211,7 @@ export const ListingProvider = ({ type, ssrProps, cr, children }) => {
 
   //Functions
   const listingLoad = () => {
+    setContactLoading(true);
     setLoading(false);
     setListingInfo(null);
     // If the status is not resolved in any way, there's no reason to continue


### PR DESCRIPTION
Byl objeven bug při kterým se při kliku z cizího listingu na listing uživatele nezapnul contact load tudíž před fetchnutím kontaktu je kontakt null a nemůže se zobrazit > client side error